### PR TITLE
In CI, don't test Ubuntu 20.04 and test Debian 13

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-         os: ['debian:11', 'debian:12', 'ubuntu:20.04', 'ubuntu:22.04', 'ubuntu:24.04']
+         os: ['debian:12', 'debian:13', 'ubuntu:22.04', 'ubuntu:24.04']
     container: ${{ matrix.os }}
     needs: build
 


### PR DESCRIPTION
Ubuntu 20.04 has EOLed.

 #92 